### PR TITLE
Fixing exercise 5 notes

### DIFF
--- a/src/__tests__/exercise/05.md
+++ b/src/__tests__/exercise/05.md
@@ -87,11 +87,8 @@ In the last exercise you wrote a test for the Login form by itself, now you'll
 be writing a test that connects that login form with a backend request for when
 the user submits the form.
 
-Note, this is the first exercise where we'll be using a `find*` query variant
-because the `username` shows up asynchronously.
-
-We'll also use `waitForElementToBeRemoved` to wait for the loading indicator to
-go away.
+We'll use `waitForElementToBeRemoved` to wait for the loading indicator to go
+away.
 
 ## Extra Credit
 

--- a/src/__tests__/exercise/05.md
+++ b/src/__tests__/exercise/05.md
@@ -52,7 +52,7 @@ test('loads and displays greeting', async () => {
 
   userEvent.click(screen.getByText('Load Greeting'))
 
-  expect(await screen.findByRole('heading')).toBeInTheDocument()
+  await waitForElementToBeRemoved(() => screen.getByText('Loading...'))
 
   expect(screen.getByRole('heading')).toHaveTextContent('hello there')
   expect(screen.getByRole('button')).toHaveAttribute('disabled')
@@ -69,9 +69,9 @@ test('handlers server error', async () => {
 
   userEvent.click(screen.getByText('Load Greeting'))
 
-  expect(await screen.findByRole('alert')).toHaveTextContent(
-    'Oops, failed to fetch!',
-  )
+  await waitForElementToBeRemoved(() => screen.getByText('Loading...'))
+
+  expect(screen.getByRole('alert')).toHaveTextContent('Oops, failed to fetch!')
   expect(screen.getByRole('button')).not.toHaveAttribute('disabled')
 })
 ```


### PR DESCRIPTION
In the notes for exercise 5 you missed a reference to the previously removed `find*` variant. It is no longer used in any final version of the exercise.

I'm not sure if you also want the example code updated from `findByRole` to `waitForElementToBeRemoved`?