### PR TITLE
Should be waitForElementToBeRemoved instead of waitFor

### DIFF
--- a/src/__tests__/exercise/05.md
+++ b/src/__tests__/exercise/05.md
@@ -33,7 +33,7 @@ example of how you can use msw for tests:
 import React from 'react'
 import {rest} from 'msw'
 import {setupServer} from 'msw/node'
-import {render, waitFor, screen} from '@testing-library/react'
+import {render, waitForElementToBeRemoved, screen} from '@testing-library/react'
 import {userEvent} from '@testing-library/user-event'
 import Fetch from '../fetch'
 


### PR DESCRIPTION
Fix a typo in the markdown file where we should import `waitForElementToBeRemoved` instead of `waitFor`