### PR TITLE
Symmetric code inside act calls

### DIFF
--- a/src/__tests__/final/06.extra-2.js
+++ b/src/__tests__/final/06.extra-2.js
@@ -39,9 +39,8 @@ test('displays the users current location', async () => {
 
   expect(screen.getByLabelText(/loading/i)).toBeInTheDocument()
 
-  await act(() => {
+  await act(async () => {
     resolve()
-    return promise
   })
 
   expect(screen.queryByLabelText(/loading/i)).not.toBeInTheDocument()

--- a/src/__tests__/final/06.js
+++ b/src/__tests__/final/06.js
@@ -38,9 +38,8 @@ test('displays the users current location', async () => {
 
   expect(screen.getByLabelText(/loading/i)).toBeInTheDocument()
 
-  await act(() => {
+  await act(async () => {
     resolve()
-    return promise
   })
 
   expect(screen.queryByLabelText(/loading/i)).not.toBeInTheDocument()


### PR DESCRIPTION
In the video of solution 2 in exercise 6 [here](https://epicreact.dev/modules/testing-react-apps/mocking-browser-apis-and-modules-solution-2), the solution code is presented as follows.

```js
await act(aync () => {
    resolve()
    await promise
})
```

While working on the second extra credit in exercise 6, I ran into the following solution code to test the error case.

https://github.com/kentcdodds/testing-react-apps/blob/296eba8b919d4e1cf909bd98761f3d9e7e080e5c/src/__tests__/final/06.extra-2.js#L73-L75

This made me question why the approaches are slightly different and then, I noticed that the solution code is different from the code presented in the video.

```js
await act(() => {
  resolve()
  return promise
})
```

I was confused and played around with these options and I realized that the promise actually doesn't need to be returned.

```js
await act(async () => {
  resolve()
})
```

After spending some time trying to wrap my head around this, I think it makes sense because the promise gets either resolved or rejected in the mock implementation so it doesn't need to be awaited or returned inside the `act` call.
So, I'm creating this PR thinking it would be nice and cleaner if we could make the code for both cases symmetric.