### PR TITLE
await promise in act

### DIFF
--- a/src/__tests__/final/06.extra-2.js
+++ b/src/__tests__/final/06.extra-2.js
@@ -39,9 +39,9 @@ test('displays the users current location', async () => {
 
   expect(screen.getByLabelText(/loading/i)).toBeInTheDocument()
 
-  await act(() => {
+  await act(async () => {
     resolve()
-    return promise
+    await promise
   })
 
   expect(screen.queryByLabelText(/loading/i)).not.toBeInTheDocument()

--- a/src/__tests__/final/06.js
+++ b/src/__tests__/final/06.js
@@ -38,9 +38,9 @@ test('displays the users current location', async () => {
 
   expect(screen.getByLabelText(/loading/i)).toBeInTheDocument()
 
-  await act(() => {
+  await act(async () => {
     resolve()
-    return promise
+    await promise
   })
 
   expect(screen.queryByLabelText(/loading/i)).not.toBeInTheDocument()


### PR DESCRIPTION
This PR changes the solution code to be the same as the video code. It awaits promise instead of returns it in the act calls.