### PR TITLE
Change hint to match video

### DIFF
--- a/src/__tests__/exercise/08.md
+++ b/src/__tests__/exercise/08.md
@@ -27,9 +27,9 @@ complicated "TestComponent." For those situations, you can try something like
 this:
 
 ```javascript
-const results = {}
+let result
 function TestComponent(props) {
-  Object.assign(results, useCustomHook())
+  result = useCustomHook(props)
   return null
 }
 


### PR DESCRIPTION
I found the hint for the extra credit 1 of exercise 8 a bit confusing as it's not aligned with the video code.
If someone used the hint from the extra credit 1, they wouldn't necessarily run into the issue with variable references in the extra credit 2.
Not sure this confusion is intended but I just thought it would be better to change the hint to help learners experience the struggles.

FYI, in the video, the following two strategies were presented to access the return value of a hook from outside.

https://github.com/kentcdodds/testing-react-apps/blob/329c071f715116fd3455d05f480c04b197fa0148/src/__tests__/final/08.extra-1.js#L10-L14

https://github.com/kentcdodds/testing-react-apps/blob/329c071f715116fd3455d05f480c04b197fa0148/src/__tests__/final/08.extra-2.js#L10-L14