### PR TITLE
fix: prop 'initialTheme' passed to ThemeProvider

### DIFF
--- a/src/__tests__/final/07.extra-2.js
+++ b/src/__tests__/final/07.extra-2.js
@@ -9,7 +9,7 @@ import EasyButton from '../../components/easy-button'
 
 function renderWithProviders(ui, {theme = 'light', ...options} = {}) {
   const Wrapper = ({children}) => (
-    <ThemeProvider value={[theme, () => {}]}>{children}</ThemeProvider>
+    <ThemeProvider initialTheme={theme}>{children}</ThemeProvider>
   )
   return render(ui, {wrapper: Wrapper, ...options})
 }


### PR DESCRIPTION
```javascript
function ThemeProvider({initialTheme = 'light', ...props}) {
  const [theme, setTheme] = React.useState(initialTheme)
  return <ThemeContext.Provider value={[theme, setTheme]} {...props} />
}
```
I think It would be better to pass `initialTheme` to `ThemeProvider` as a prop  than passing `value`.