### PR TITLE
Updated code to be in sync with the video

### DIFF
--- a/src/__tests__/final/08.extra-2.js
+++ b/src/__tests__/final/08.extra-2.js
@@ -8,11 +8,11 @@ import useCounter from '../../components/use-counter'
 
 function setup({initialProps} = {}) {
   const result = {}
-  function TestComponent(props) {
-    result.current = useCounter(props)
+  function TestComponent() {
+    result.current = useCounter(initialProps)
     return null
   }
-  render(<TestComponent {...initialProps} />)
+  render(<TestComponent />)
   return result
 }
 


### PR DESCRIPTION
Based on the conversation [here](https://github.com/kentcdodds/testing-react-apps/pull/72), this PR brings the code in the repo in sync with what is present in the video.

In the video, `initialProps` is directly passed to the `useCounter` hook and not via the `TestComponent`

